### PR TITLE
Allow ZipExtractionInstaller for ToolConfigurations

### DIFF
--- a/src/test/groovy/com/rei/jenkins/systemdsl/JenkinsSystemConfigDslTest.groovy
+++ b/src/test/groovy/com/rei/jenkins/systemdsl/JenkinsSystemConfigDslTest.groovy
@@ -187,6 +187,15 @@ echo "Shell Stuff"
                 }
 
                 jdk {
+                    name('JDK11')
+                    downloadArchive(
+                            'https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz',
+                            '',
+                            'jdk-11.0.1'
+                    )
+                }
+
+                jdk {
                     name('JDK9')
                     version('jdk-9.0.4-oth-JPR')
                     oracleUsername('jblow')


### PR DESCRIPTION
Allows an option to downloadArchive for any tool.

Also will no longer attempt to install the primary ToolInstaller if the `version` is null so that a tool can be install with only custom commands like downloads, shell scripts or batch scripts.